### PR TITLE
Remove duplicate entries from setAdminOnlyLimits.sh and refactored code

### DIFF
--- a/artifacts/scripts/setAdminOnlyLimits.sh
+++ b/artifacts/scripts/setAdminOnlyLimits.sh
@@ -1,175 +1,57 @@
-if [[ -z $ADMIN_ONLY_PROJECT_ADD ]]; then
-echo "No admin only project add flag"
-else sed -i "s@ADMIN_ONLY_PROJECT_ADD.*@ADMIN_ONLY_PROJECT_ADD\t$ADMIN_ONLY_PROJECT_ADD@g" /opt/semosshome/RDF_Map.prop
-fi
+#!/bin/bash
 
-if [[ -z $ADMIN_ONLY_PROJECT_DELETE ]]; then 
-echo "No admin only project delete flag"
-else sed -i "s@ADMIN_ONLY_PROJECT_DELETE.*@ADMIN_ONLY_PROJECT_DELETE\t$ADMIN_ONLY_PROJECT_DELETE@g" /opt/semosshome/RDF_Map.prop
-fi
+PROP_FILE="/opt/semosshome/RDF_Map.prop"
 
-if [[ -z $ADMIN_ONLY_PROJECT_ADD_ACCESS ]]; then 
-echo "No admin only project add access flag"
-else sed -i "s@ADMIN_ONLY_PROJECT_ADD_ACCESS.*@ADMIN_ONLY_PROJECT_ADD_ACCESS\t$ADMIN_ONLY_PROJECT_ADD_ACCESS@g" /opt/semosshome/RDF_Map.prop
-fi
+# List all the relevant environment variable names as they appear in property file
 
-if [[ -z $ADMIN_ONLY_PROJECT_SET_PUBLIC ]]; then
-echo "No admin only project set public flag"
-else sed -i "s@ADMIN_ONLY_PROJECT_SET_PUBLIC.*@ADMIN_ONLY_PROJECT_SET_PUBLIC\t$ADMIN_ONLY_PROJECT_SET_PUBLIC@g" /opt/semosshome/RDF_Map.prop
-fi
+VARS=(
+    ADMIN_ONLY_PROJECT_ADD
+    ADMIN_ONLY_PROJECT_DELETE
+    ADMIN_ONLY_PROJECT_ADD_ACCESS
+    ADMIN_ONLY_PROJECT_SET_PUBLIC
+    ADMIN_ONLY_PROJECT_SET_DISCOVERABLE
+    ADMIN_ONLY_INSIGHT_SET_PUBLIC
+    ADMIN_ONLY_INSIGHT_ADD_ACCESS
+    ADMIN_ONLY_INSIGHT_SHARE
+    ADMIN_ONLY_DB_ADD
+    ADMIN_ONLY_DB_DELETE
+    ADMIN_ONLY_DB_ADD_ACCESS
+    ADMIN_ONLY_DB_SET_PUBLIC
+    ADMIN_ONLY_DB_SET_DISCOVERABLE
+    ADMIN_ONLY_MODEL_ADD
+    ADMIN_ONLY_MODEL_DELETE
+    ADMIN_ONLY_MODEL_ADD_ACCESS
+    ADMIN_ONLY_MODEL_SET_PUBLIC
+    ADMIN_ONLY_MODEL_SET_DISCOVERABLE
+    ADMIN_ONLY_STORAGE_ADD
+    ADMIN_ONLY_STORAGE_DELETE
+    ADMIN_ONLY_STORAGE_ADD_ACCESS
+    ADMIN_ONLY_STORAGE_SET_PUBLIC
+    ADMIN_ONLY_STORAGE_SET_DISCOVERABLE
+    ADMIN_ONLY_VECTOR_ADD
+    ADMIN_ONLY_VECTOR_DELETE
+    ADMIN_ONLY_VECTOR_ADD_ACCESS
+    ADMIN_ONLY_VECTOR_SET_PUBLIC
+    ADMIN_ONLY_VECTOR_SET_DISCOVERABLE
+    ADMIN_ONLY_FUNCTION_ADD
+    ADMIN_ONLY_FUNCTION_DELETE
+    ADMIN_ONLY_FUNCTION_ADD_ACCESS
+    ADMIN_ONLY_FUNCTION_SET_PUBLIC
+    ADMIN_ONLY_FUNCTION_SET_DISCOVERABLE
+    ADMIN_ONLY_VIEW_MENU_BAR
+    ADMIN_ONLY_NON_APPROVED_PROD_ITEM
+)
 
-if [[ -z $ADMIN_ONLY_PROJECT_SET_DISCOVERABLE ]]; then
-echo "No admin only project set discoverable flag"
-else sed -i "s@ADMIN_ONLY_PROJECT_SET_DISCOVERABLE.*@ADMIN_ONLY_PROJECT_SET_DISCOVERABLE\t$ADMIN_ONLY_PROJECT_SET_DISCOVERABLE@g" /opt/semosshome/RDF_Map.prop
-fi
+# if [[ -z $ADMIN_ONLY_FUNCTION_ADD ]]; then
+# echo "No admin only function add flag"
+# else sed -i "s@ADMIN_ONLY_FUNCTION_ADD.*@ADMIN_ONLY_FUNCTION_ADD\t$ADMIN_ONLY_FUNCTION_ADD@g" /opt/semosshome/RDF_Map.prop
+# fi
 
-if [[ -z $ADMIN_ONLY_INSIGHT_SET_PUBLIC ]]; then
-echo "No admin only insight set public flag"
-else sed -i "s@ADMIN_ONLY_INSIGHT_SET_PUBLIC.*@ADMIN_ONLY_INSIGHT_SET_PUBLIC\t$ADMIN_ONLY_INSIGHT_SET_PUBLIC@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_INSIGHT_ADD_ACCESS ]]; then
-echo "No admin only insight add access flag"
-else sed -i "s@ADMIN_ONLY_INSIGHT_ADD_ACCESS.*@ADMIN_ONLY_INSIGHT_ADD_ACCESS\t$ADMIN_ONLY_INSIGHT_ADD_ACCESS@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_INSIGHT_SHARE ]]; then
-echo "No admin only insight share flag"
-else sed -i "s@ADMIN_ONLY_INSIGHT_SHARE.*@ADMIN_ONLY_INSIGHT_SHARE\t$ADMIN_ONLY_INSIGHT_SHARE@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_DB_ADD ]]; then
-echo "No admin only db add flag"
-else sed -i "s@ADMIN_ONLY_DB_ADD.*@ADMIN_ONLY_DB_ADD\t$ADMIN_ONLY_DB_ADD@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_DB_DELETE ]]; then 
-echo "No admin only db delete flag"
-else sed -i "s@ADMIN_ONLY_DB_DELETE.*@ADMIN_ONLY_DB_DELETE\t$ADMIN_ONLY_DB_DELETE@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_DB_ADD_ACCESS ]]; then 
-echo "No admin only db add access flag"
-else sed -i "s@ADMIN_ONLY_DB_ADD_ACCESS.*@ADMIN_ONLY_DB_ADD_ACCESS\t$ADMIN_ONLY_DB_ADD_ACCESS@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_DB_SET_PUBLIC ]]; then
-echo "No admin only db set public flag"
-else sed -i "s@ADMIN_ONLY_DB_SET_PUBLIC.*@ADMIN_ONLY_DB_SET_PUBLIC\t$ADMIN_ONLY_DB_SET_PUBLIC@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_DB_SET_DISCOVERABLE ]]; then
-echo "No admin only db set discoverable flag"
-else sed -i "s@ADMIN_ONLY_DB_SET_DISCOVERABLE.*@ADMIN_ONLY_DB_SET_DISCOVERABLE\t$ADMIN_ONLY_DB_SET_DISCOVERABLE@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_MODEL_ADD ]]; then
-echo "No admin only model add flag"
-else sed -i "s@ADMIN_ONLY_MODEL_ADD.*@ADMIN_ONLY_MODEL_ADD\t$ADMIN_ONLY_MODEL_ADD@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_MODEL_DELETE ]]; then 
-echo "No admin only model delete flag"
-else sed -i "s@ADMIN_ONLY_MODEL_DELETE.*@ADMIN_ONLY_MODEL_DELETE\t$ADMIN_ONLY_MODEL_DELETE@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_MODEL_ADD_ACCESS ]]; then 
-echo "No admin only model add access flag"
-else sed -i "s@ADMIN_ONLY_MODEL_ADD_ACCESS.*@ADMIN_ONLY_MODEL_ADD_ACCESS\t$ADMIN_ONLY_MODEL_ADD_ACCESS@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_MODEL_SET_PUBLIC ]]; then
-echo "No admin only model set public flag"
-else sed -i "s@ADMIN_ONLY_MODEL_SET_PUBLIC.*@ADMIN_ONLY_MODEL_SET_PUBLIC\t$ADMIN_ONLY_MODEL_SET_PUBLIC@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_MODEL_SET_DISCOVERABLE ]]; then
-echo "No admin only model set discoverable flag"
-else sed -i "s@ADMIN_ONLY_MODEL_SET_DISCOVERABLE.*@ADMIN_ONLY_MODEL_SET_DISCOVERABLE\t$ADMIN_ONLY_MODEL_SET_DISCOVERABLE@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_STORAGE_ADD ]]; then
-echo "No admin only storage add flag"
-else sed -i "s@ADMIN_ONLY_STORAGE_ADD.*@ADMIN_ONLY_STORAGE_ADD\t$ADMIN_ONLY_STORAGE_ADD@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_STORAGE_DELETE ]]; then 
-echo "No admin only storage delete flag"
-else sed -i "s@ADMIN_ONLY_STORAGE_DELETE.*@ADMIN_ONLY_STORAGE_DELETE\t$ADMIN_ONLY_STORAGE_DELETE@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_STORAGE_ADD_ACCESS ]]; then 
-echo "No admin only storage add access flag"
-else sed -i "s@ADMIN_ONLY_STORAGE_ADD_ACCESS.*@ADMIN_ONLY_STORAGE_ADD_ACCESS\t$ADMIN_ONLY_STORAGE_ADD_ACCESS@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_STORAGE_SET_PUBLIC ]]; then
-echo "No admin only storage set public flag"
-else sed -i "s@ADMIN_ONLY_STORAGE_SET_PUBLIC.*@ADMIN_ONLY_STORAGE_SET_PUBLIC\t$ADMIN_ONLY_STORAGE_SET_PUBLIC@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_STORAGE_SET_DISCOVERABLE ]]; then
-echo "No admin only storage set discoverable flag"
-else sed -i "s@ADMIN_ONLY_STORAGE_SET_DISCOVERABLE.*@ADMIN_ONLY_STORAGE_SET_DISCOVERABLE\t$ADMIN_ONLY_STORAGE_SET_DISCOVERABLE@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_VECTOR_ADD ]]; then
-echo "No admin only vector add flag"
-else sed -i "s@ADMIN_ONLY_VECTOR_ADD.*@ADMIN_ONLY_VECTOR_ADD\t$ADMIN_ONLY_VECTOR_ADD@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_VECTOR_DELETE ]]; then 
-echo "No admin only vector delete flag"
-else sed -i "s@ADMIN_ONLY_VECTOR_DELETE.*@ADMIN_ONLY_VECTOR_DELETE\t$ADMIN_ONLY_VECTOR_DELETE@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_VECTOR_ADD_ACCESS ]]; then 
-echo "No admin only vector add access flag"
-else sed -i "s@ADMIN_ONLY_VECTOR_ADD_ACCESS.*@ADMIN_ONLY_VECTOR_ADD_ACCESS\t$ADMIN_ONLY_VECTOR_ADD_ACCESS@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_VECTOR_SET_PUBLIC ]]; then
-echo "No admin only vector set public flag"
-else sed -i "s@ADMIN_ONLY_VECTOR_SET_PUBLIC.*@ADMIN_ONLY_VECTOR_SET_PUBLIC\t$ADMIN_ONLY_VECTOR_SET_PUBLIC@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_VECTOR_SET_DISCOVERABLE ]]; then
-echo "No admin only vector set discoverable flag"
-else sed -i "s@ADMIN_ONLY_VECTOR_SET_DISCOVERABLE.*@ADMIN_ONLY_VECTOR_SET_DISCOVERABLE\t$ADMIN_ONLY_VECTOR_SET_DISCOVERABLE@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_FUNCTION_ADD ]]; then
-echo "No admin only function add flag"
-else sed -i "s@ADMIN_ONLY_FUNCTION_ADD.*@ADMIN_ONLY_FUNCTION_ADD\t$ADMIN_ONLY_FUNCTION_ADD@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_FUNCTION_ADD ]]; then 
-echo "No admin only function delete flag"
-else sed -i "s@ADMIN_ONLY_FUNCTION_ADD.*@ADMIN_ONLY_FUNCTION_ADD\t$ADMIN_ONLY_FUNCTION_ADD@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_FUNCTION_ADD ]]; then 
-echo "No admin only function add access flag"
-else sed -i "s@ADMIN_ONLY_FUNCTION_ADD.*@ADMIN_ONLY_FUNCTION_ADD\t$ADMIN_ONLY_FUNCTION_ADD@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_FUNCTION_ADD ]]; then
-echo "No admin only function set public flag"
-else sed -i "s@ADMIN_ONLY_FUNCTION_ADD.*@ADMIN_ONLY_FUNCTION_ADD\t$ADMIN_ONLY_FUNCTION_ADD@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_FUNCTION_ADD ]]; then
-echo "No admin only function set discoverable flag"
-else sed -i "s@ADMIN_ONLY_FUNCTION_ADD.*@ADMIN_ONLY_FUNCTION_ADD\t$ADMIN_ONLY_FUNCTION_ADD@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_VIEW_MENU_BAR ]]; then
-echo "No admin only view menu bar flag"
-else sed -i "s@ADMIN_ONLY_VIEW_MENU_BAR.*@ADMIN_ONLY_VIEW_MENU_BAR\t$ADMIN_ONLY_VIEW_MENU_BAR@g" /opt/semosshome/RDF_Map.prop
-fi
-
-if [[ -z $ADMIN_ONLY_NON_APPROVED_PROD_ITEM ]]; then
-echo "No admin only non approved prod item flag"
-else sed -i "s@ADMIN_ONLY_NON_APPROVED_PROD_ITEM.*@ADMIN_ONLY_NON_APPROVED_PROD_ITEM\t$ADMIN_ONLY_NON_APPROVED_PROD_ITEM@g" /opt/semosshome/RDF_Map.prop
-fi
-
+for VAR in "${VARS[@]}"; do
+  VALUE="${!VAR}"
+  if [[ -z $VALUE ]]; then
+    echo "No ${VAR,,//_/ } flag"   # Lowercase varname, replace _ with space for readable messages
+  else
+    sed -i "s@^${VAR}.*@${VAR}\t${VALUE}@g" "$PROP_FILE"
+  fi
+done


### PR DESCRIPTION
## Description
Refactors the artifacts/scripts/setAdminOnlyLimits.sh file and removes the duplicate entries

## Changes Made
Change multiple "if" statements for a "for" loop

## How to Test
1. Steps to reproduce/test the behavior
Using the docker compose file from the [semoss project](https://github.com/SEMOSS/Semoss/blob/dev/docker-compose-examples/docker_compose/compose.yaml) project and mount the local script folder as a volume.
```
volumes:
      - semoss_db:/opt/semosshome/db
      - semoss_project:/opt/semosshome/project
      - semoss_model:/opt/semosshome/model
      - semoss_vector:/opt/semosshome/vector
      - semoss_storage:/opt/semosshome/storage
      - semoss_function:/opt/semosshome/function
      - semoss_guardrail:/opt/semosshome/guardrail
      - ~/semoss-artifacts/artifacts/scripts:/opt/semoss-artifacts/artifacts/scripts:rw
```
2. Enter the following environment variables in the docker compose file that are set by the setAdminOnlyLimits.sh script:
```
#Limit to only admins ('false' | 'true')
      ADMIN_ONLY_PROJECT_ADD: 'true'
      ADMIN_ONLY_PROJECT_DELETE: 'true'
      ADMIN_ONLY_PROJECT_ADD_ACCESS: 'true'
      ADMIN_ONLY_PROJECT_SET_PUBLIC: 'true'
      ADMIN_ONLY_PROJECT_SET_DISCOVERABLE: 'true'
      ADMIN_ONLY_INSIGHT_SET_PUBLIC: 'true'
      ADMIN_ONLY_INSIGHT_ADD_ACCESS: 'true'
      ADMIN_ONLY_INSIGHT_SHARE: 'true'
      ADMIN_ONLY_DB_ADD: 'false'
      ADMIN_ONLY_DB_DELETE: 'true'
      ADMIN_ONLY_DB_ADD_ACCESS: 'true'
      ADMIN_ONLY_DB_SET_PUBLIC: 'true'
      ADMIN_ONLY_DB_SET_DISCOVERABLE: 'true'
      ADMIN_ONLY_MODEL_ADD: 'true'
      ADMIN_ONLY_MODEL_DELETE: 'true'
      ADMIN_ONLY_MODEL_ADD_ACCESS: 'true'
      ADMIN_ONLY_MODEL_SET_PUBLIC: 'true'
      ADMIN_ONLY_MODEL_SET_DISCOVERABLE: 'true'
      ADMIN_ONLY_STORAGE_ADD: 'true'
      ADMIN_ONLY_STORAGE_DELETE: 'true'
      ADMIN_ONLY_STORAGE_ADD_ACCESS: 'true'
      ADMIN_ONLY_STORAGE_SET_PUBLIC: 'true'
      ADMIN_ONLY_STORAGE_SET_DISCOVERABLE: 'true'
      ADMIN_ONLY_VECTOR_ADD: 'true'
      ADMIN_ONLY_VECTOR_DELETE: 'true'
      ADMIN_ONLY_VECTOR_ADD_ACCESS: 'true'
      ADMIN_ONLY_VECTOR_SET_PUBLIC: 'true'
      ADMIN_ONLY_VECTOR_SET_DISCOVERABLE: 'true'
      ADMIN_ONLY_FUNCTION_ADD: 'true'
      ADMIN_ONLY_FUNCTION_DELETE: 'true'
      ADMIN_ONLY_FUNCTION_ADD_ACCESS: 'true'
      ADMIN_ONLY_FUNCTION_SET_PUBLIC: 'true'
      ADMIN_ONLY_FUNCTION_SET_DISCOVERABLE: 'true'
      ADMIN_ONLY_VIEW_MENU_BAR: 'false'
      ADMIN_ONLY_NON_APPROVED_PROD_ITEM: 'true'
```
3. Run docker compose file
5. Expected outcomes
The environment values entered in the docker file should be the same as those written in the container's /opt/semosshome/RDF_Map.prop file

## Notes
N/a