### PR TITLE
Add helper script to install playwright linux lib dependencies

### DIFF
--- a/artifacts/dockerBuilder_scripts/install_Playwright_linux_dependencies.sh
+++ b/artifacts/dockerBuilder_scripts/install_Playwright_linux_dependencies.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Create POM file to manage Playwright 1.48.0 native linux lib dependencies
+cat << 'EOF' > /tmp/pom.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.microsoft.playwright</groupId>
+  <artifactId>playwright-minimal</artifactId>
+  <version>0.1</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>playwright</artifactId>
+      <version>1.48.0</version>
+    </dependency>
+  </dependencies>
+</project>	
+EOF
+
+# Install Playwright dependencies and the chromium browser binaries
+mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps chromium"


### PR DESCRIPTION
## Description
Add a shell script file to the artifacts/dockerBuilder_scripts/ folder that adds POM file declaring the Playwright dependency and executes `mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps chromium"` to install lib dependencies and downloads the chromium binaries used by Playwright

## Changes Made
- Adds artifacts/dockerBuilder_scripts/install_Playwright_linux_dependencies.sh

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Script creates POM.xml file in the /tmp folder
2. The `mvn exec` command installs the lib dependencies
3. Executing `mvn` commands to build POM files that have Playwright dependencies or running `apt-get install ` should return the following:
```
[INFO] --- exec-maven-plugin:3.5.1:java (default-cli) @ playwright-minimal ---
Installing dependencies...
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Hit:4 http://security.ubuntu.com/ubuntu jammy-security InRelease
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
fonts-freefont-ttf is already the newest version (20120503-10build1).
fonts-liberation is already the newest version (1:1.07.4-11).
libasound2 is already the newest version (1.2.6.1-1ubuntu1).
libatk-bridge2.0-0 is already the newest version (2.38.0-3).
libatk1.0-0 is already the newest version (2.36.0-3build1).
...
xvfb is already the newest version (2:21.1.4-2ubuntu1.7~22.04.15).
0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
```

## Notes
The playwright version depends on the version declared on the [pom.xml](https://github.com/SEMOSS/Semoss/blob/dev/pom.xml) file in the Semoss project.